### PR TITLE
fix: make CnpSiteState.CurrentCulture non-nullable

### DIFF
--- a/src/CretNet.Platform.Blazor/Services/Countries/CountryService.cs
+++ b/src/CretNet.Platform.Blazor/Services/Countries/CountryService.cs
@@ -30,7 +30,7 @@ public class CountryService : ICountryService
 
         return countries;
     }
-    
+
     public Country GetCountry(string twoLetterIsoCode)
     {
         var cultureInfo = _cnpSiteState.Value.CurrentCulture;

--- a/src/CretNet.Platform.Blazor/State/CnpSiteFeature.cs
+++ b/src/CretNet.Platform.Blazor/State/CnpSiteFeature.cs
@@ -1,4 +1,5 @@
-﻿using Fluxor;
+﻿using System.Globalization;
+using Fluxor;
 
 namespace CretNet.Platform.Blazor.State;
 
@@ -8,5 +9,5 @@ public class CnpSiteFeature : Feature<CnpSiteState>
 
     protected override CnpSiteState GetInitialState() =>
         new CnpSiteState(
-            CurrentCulture: null);
+            CurrentCulture: CultureInfo.CurrentCulture);
 }

--- a/src/CretNet.Platform.Blazor/State/CnpSiteState.cs
+++ b/src/CretNet.Platform.Blazor/State/CnpSiteState.cs
@@ -3,6 +3,6 @@
 namespace CretNet.Platform.Blazor.State;
 
 public record CnpSiteState(
-    CultureInfo? CurrentCulture)
+    CultureInfo CurrentCulture)
 {
 }


### PR DESCRIPTION
CnpSiteState initialized CurrentCulture as null, causing a NullReferenceException in CountryService when CnpCountrySelect rendered before a ChangeCultureAction was dispatched (e.g. in Blazor WebAssembly apps).

- Make CurrentCulture non-nullable (CultureInfo instead of CultureInfo?)
- Default CnpSiteFeature initial state to CultureInfo.CurrentCulture