### PR TITLE
feat(blazor): add durable notification inbox

### DIFF
--- a/src/CretNet.Platform.Blazor/Components/CnpNotificationCenter.razor
+++ b/src/CretNet.Platform.Blazor/Components/CnpNotificationCenter.razor
@@ -1,22 +1,194 @@
-﻿@implements IDialogContentComponent<GlobalState>
-@inject IMessageService MessageService
+@using System.Globalization
+@using CretNet.Platform.Blazor.Notifications
+@implements IDialogContentComponent<GlobalState>
+@implements IDisposable
+@inject CnpNotificationState Notifications
+@inject NavigationManager Navigation
+@* The panel itself is supplied by Fluent UI; all content/state is CretNet-owned. *@
 
-<div>
+<section class="cnp-inbox" aria-label="Meldingen">
+    <header class="cnp-inbox-header">
+        <div>
+            <span class="cnp-inbox-eyebrow">ACTIVITEIT</span>
+            <h2>Meldingen</h2>
+            <p>@Summary</p>
+        </div>
+        <button type="button" class="cnp-icon-action" title="Sluiten" aria-label="Sluiten" @onclick="CloseAsync">×</button>
+    </header>
 
-    <FluentStack>
-        <FluentSpacer />
+    <nav class="cnp-inbox-filters" aria-label="Meldingen filteren">
+        @FilterButton(CnpNotificationFilter.All, "Alles")
+        @FilterButton(CnpNotificationFilter.Unread, "Ongelezen")
+        @FilterButton(CnpNotificationFilter.ActionRequired, $"Actie {Notifications.ActionRequiredCount}")
+        @FilterButton(CnpNotificationFilter.Archived, "Archief")
+    </nav>
 
-        <FluentAnchor Appearance="@Appearance.Hypertext" Href="javascript:void(0)" OnClick="@(e => MessageService.Clear("MESSAGES_NOTIFICATION_CENTER") )">
-            Dismiss all
-        </FluentAnchor>
-    </FluentStack>
+    @if (Notifications.UnreadCount > 0 && Notifications.Filter != CnpNotificationFilter.Archived)
+    {
+        <div class="cnp-inbox-toolbar">
+            <span>@Notifications.UnreadCount ongelezen</span>
+            <button type="button" @onclick="MarkAllReadAsync">Alles gelezen</button>
+        </div>
+    }
 
-    <br />
+    <div class="cnp-inbox-content" aria-live="polite">
+        @if (Notifications.IsLoading)
+        {
+            <div class="cnp-inbox-loading"><span></span><span></span><span></span></div>
+        }
+        else if (Notifications.Error is not null)
+        {
+            <div class="cnp-inbox-empty cnp-inbox-error">
+                <strong>Meldingen konden niet worden geladen</strong>
+                <p>@Notifications.Error</p>
+                <button type="button" @onclick="RefreshAsync">Opnieuw proberen</button>
+            </div>
+        }
+        else if (Notifications.Items.Count == 0)
+        {
+            <div class="cnp-inbox-empty">
+                <span class="cnp-empty-mark">✓</span>
+                <strong>@EmptyTitle</strong>
+                <p>@EmptyText</p>
+            </div>
+        }
+        else
+        {
+            @foreach (var group in Notifications.Items.GroupBy(item => DayLabel(item.OccurredAt)))
+            {
+                <div class="cnp-inbox-day">@group.Key</div>
+                @foreach (var item in group)
+                {
+                    <article class="cnp-inbox-item @SeverityClass(item) @(item.ReadAt is null ? "is-unread" : null)">
+                        <button type="button" class="cnp-item-main" @onclick="() => OpenAsync(item)">
+                            <span class="cnp-item-indicator" aria-hidden="true"></span>
+                            <span class="cnp-item-copy">
+                                <span class="cnp-item-meta">
+                                    <span>@CategoryLabel(item.Category)</span>
+                                    <time datetime="@item.OccurredAt.ToString("O")">@TimeLabel(item.OccurredAt)</time>
+                                </span>
+                                <strong>@item.Title</strong>
+                                <span class="cnp-item-message">@item.Message</span>
+                                @if (item.RequiresAction)
+                                {
+                                    <span class="cnp-action-label">Actie vereist</span>
+                                }
+                            </span>
+                            @if (item.ActionPath is not null)
+                            {
+                                <span class="cnp-item-chevron" aria-hidden="true">›</span>
+                            }
+                        </button>
+                        <div class="cnp-item-actions">
+                            <button type="button" @onclick="() => ToggleReadAsync(item)">
+                                @(item.ReadAt is null ? "Gelezen" : "Ongelezen")
+                            </button>
+                            @if (Notifications.Filter != CnpNotificationFilter.Archived)
+                            {
+                                <button type="button" @onclick="() => ArchiveAsync(item)">Archiveer</button>
+                            }
+                        </div>
+                    </article>
+                }
+            }
 
-    <FluentMessageBarProvider Section="MESSAGES_NOTIFICATION_CENTER" MaxMessageCount="-1" Type="@MessageType.Notification" />
-</div>
+            @if (Notifications.NextCursor is not null)
+            {
+                <button type="button" class="cnp-load-more" disabled="@Notifications.IsLoadingMore" @onclick="LoadMoreAsync">
+                    @(Notifications.IsLoadingMore ? "Laden…" : "Eerdere meldingen")
+                </button>
+            }
+        }
+    </div>
+</section>
 
 @code {
-    [Parameter]
-    public GlobalState Content { get; set; } = default!;
+    [Parameter] public GlobalState Content { get; set; } = default!;
+    [CascadingParameter] public FluentDialog Dialog { get; set; } = default!;
+
+    private string Summary => Notifications.ActionRequiredCount > 0
+        ? $"{Notifications.ActionRequiredCount} vragen je aandacht"
+        : "Je bent helemaal bij";
+
+    private string EmptyTitle => Notifications.Filter switch
+    {
+        CnpNotificationFilter.Archived => "Nog niets gearchiveerd",
+        CnpNotificationFilter.ActionRequired => "Geen openstaande acties",
+        CnpNotificationFilter.Unread => "Alles gelezen",
+        _ => "Nog geen meldingen"
+    };
+
+    private string EmptyText => Notifications.Filter == CnpNotificationFilter.All
+        ? "Belangrijke achtergrondresultaten verschijnen voortaan hier."
+        : "Er zijn geen meldingen voor deze selectie.";
+
+    protected override void OnInitialized()
+    {
+        Notifications.Changed += OnChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+            await Notifications.RefreshAsync();
+    }
+
+    private RenderFragment FilterButton(CnpNotificationFilter filter, string label) => @<button
+        type="button"
+        class="@(Notifications.Filter == filter ? "is-active" : null)"
+        aria-pressed="@(Notifications.Filter == filter)"
+        @onclick="() => ChangeFilterAsync(filter)">@label</button>;
+
+    private Task ChangeFilterAsync(CnpNotificationFilter filter) => Notifications.RefreshAsync(filter);
+    private Task RefreshAsync() => Notifications.RefreshAsync();
+    private Task LoadMoreAsync() => Notifications.LoadMoreAsync();
+    private Task MarkAllReadAsync() => Notifications.MarkAllReadAsync();
+    private Task ToggleReadAsync(CnpNotificationItem item) => Notifications.SetReadAsync(item, item.ReadAt is null);
+    private Task ArchiveAsync(CnpNotificationItem item) => Notifications.ArchiveAsync(item);
+
+    private async Task OpenAsync(CnpNotificationItem item)
+    {
+        if (item.ReadAt is null)
+            await Notifications.SetReadAsync(item, true);
+        if (item.ActionPath is null)
+            return;
+
+        Navigation.NavigateTo(item.ActionPath);
+        await CloseAsync();
+    }
+
+    private Task CloseAsync() => Dialog.CancelAsync();
+
+    private static string SeverityClass(CnpNotificationItem item) => item.Severity switch
+    {
+        CnpNotificationSeverity.Error => "is-error",
+        CnpNotificationSeverity.Warning => "is-warning",
+        CnpNotificationSeverity.Success => "is-success",
+        _ => "is-info"
+    };
+
+    private static string CategoryLabel(string category) => category switch
+    {
+        "Billing" => "Facturatie",
+        "Payments" => "Betalingen",
+        "Work" => "Werk",
+        "Inventory" => "Voorraad",
+        _ => "Systeem"
+    };
+
+    private static string DayLabel(DateTimeOffset value)
+    {
+        var local = value.ToLocalTime().Date;
+        var today = DateTime.Today;
+        if (local == today)
+            return "Vandaag";
+        if (local == today.AddDays(-1))
+            return "Gisteren";
+        return local.ToString("dddd d MMMM", CultureInfo.CurrentCulture);
+    }
+
+    private static string TimeLabel(DateTimeOffset value) => value.ToLocalTime().ToString("HH:mm");
+    private void OnChanged() => _ = InvokeAsync(StateHasChanged);
+
+    public void Dispose() => Notifications.Changed -= OnChanged;
 }

--- a/src/CretNet.Platform.Blazor/Components/CnpNotificationCenter.razor.css
+++ b/src/CretNet.Platform.Blazor/Components/CnpNotificationCenter.razor.css
@@ -1,0 +1,68 @@
+.cnp-inbox {
+    --inbox-ink: var(--cn-text, #1d2320);
+    --inbox-muted: var(--cn-text-muted, #67706b);
+    --inbox-line: var(--cn-border, #e2e7e3);
+    --inbox-surface: var(--cn-surface, #fff);
+    --inbox-soft: var(--cn-bg, #f5f7f5);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: min(760px, calc(100vh - 48px));
+    margin: -20px;
+    background: var(--inbox-surface);
+    color: var(--inbox-ink);
+    font-family: var(--cn-font, ui-sans-serif, system-ui, sans-serif);
+}
+
+.cnp-inbox-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 26px 24px 18px;
+    border-bottom: 1px solid var(--inbox-line);
+    background: linear-gradient(145deg, color-mix(in srgb, var(--cn-accent, #17af3d) 8%, var(--inbox-surface)), var(--inbox-surface) 68%);
+}
+
+.cnp-inbox-eyebrow { color: var(--cn-accent, #17af3d); font-size: .65rem; font-weight: 850; letter-spacing: .16em; }
+.cnp-inbox-header h2 { margin: 5px 0 2px; font-size: 1.55rem; letter-spacing: -.035em; }
+.cnp-inbox-header p { margin: 0; color: var(--inbox-muted); font-size: .82rem; }
+.cnp-icon-action { width: 34px; height: 34px; border: 1px solid var(--inbox-line); border-radius: 50%; background: color-mix(in srgb, var(--inbox-surface) 82%, transparent); color: var(--inbox-muted); font: 400 1.35rem/1 inherit; cursor: pointer; }
+
+.cnp-inbox-filters { display: flex; gap: 5px; overflow-x: auto; padding: 12px 18px 10px; border-bottom: 1px solid var(--inbox-line); scrollbar-width: none; }
+.cnp-inbox-filters button { border: 0; border-radius: 7px; background: transparent; color: var(--inbox-muted); padding: 7px 10px; font: 700 .73rem inherit; white-space: nowrap; cursor: pointer; }
+.cnp-inbox-filters button.is-active { background: var(--inbox-ink); color: var(--inbox-surface); }
+
+.cnp-inbox-toolbar { display: flex; align-items: center; justify-content: space-between; padding: 9px 20px; background: var(--inbox-soft); color: var(--inbox-muted); font-size: .72rem; }
+.cnp-inbox-toolbar button, .cnp-item-actions button { border: 0; background: none; color: var(--cn-accent-strong, #128f32); font: 750 .7rem inherit; cursor: pointer; }
+.cnp-inbox-content { flex: 1; overflow-y: auto; padding-bottom: 24px; }
+.cnp-inbox-day { padding: 18px 22px 7px; color: var(--inbox-muted); font-size: .66rem; font-weight: 850; letter-spacing: .09em; text-transform: uppercase; }
+
+.cnp-inbox-item { margin: 0 14px 8px; overflow: hidden; border: 1px solid var(--inbox-line); border-radius: 11px; background: var(--inbox-surface); transition: border-color 140ms ease, transform 140ms ease; }
+.cnp-inbox-item:hover { border-color: color-mix(in srgb, var(--cn-accent, #17af3d) 38%, var(--inbox-line)); transform: translateY(-1px); }
+.cnp-inbox-item.is-unread { box-shadow: inset 3px 0 var(--cn-accent, #17af3d); }
+.cnp-item-main { display: grid; grid-template-columns: 10px minmax(0, 1fr) 12px; gap: 8px; width: 100%; border: 0; background: transparent; color: inherit; padding: 13px 13px 10px; text-align: left; font: inherit; cursor: pointer; }
+.cnp-item-indicator { width: 7px; height: 7px; margin-top: 5px; border-radius: 50%; background: #5e7ea8; }
+.is-success .cnp-item-indicator { background: var(--cn-accent, #17af3d); }
+.is-warning .cnp-item-indicator { background: #d68a19; }
+.is-error .cnp-item-indicator { background: #cf3434; }
+.cnp-item-copy { display: grid; min-width: 0; gap: 4px; }
+.cnp-item-meta { display: flex; justify-content: space-between; gap: 8px; color: var(--inbox-muted); font-size: .65rem; font-weight: 650; }
+.cnp-item-copy strong { font-size: .84rem; letter-spacing: -.01em; }
+.cnp-item-message { display: -webkit-box; overflow: hidden; color: var(--inbox-muted); font-size: .75rem; line-height: 1.45; -webkit-box-orient: vertical; -webkit-line-clamp: 3; }
+.cnp-action-label { width: max-content; margin-top: 3px; border-radius: 5px; background: #fff0db; color: #9b5900; padding: 3px 6px; font-size: .62rem; font-weight: 800; text-transform: uppercase; }
+.cnp-item-chevron { align-self: center; color: var(--inbox-muted); font-size: 1.25rem; }
+.cnp-item-actions { display: flex; gap: 12px; padding: 0 13px 9px 30px; opacity: .7; }
+.cnp-item-actions button:last-child { color: var(--inbox-muted); }
+
+.cnp-inbox-empty { display: grid; justify-items: center; gap: 8px; padding: 72px 30px; color: var(--inbox-muted); text-align: center; }
+.cnp-inbox-empty strong { color: var(--inbox-ink); font-size: .95rem; }
+.cnp-inbox-empty p { max-width: 280px; margin: 0; font-size: .78rem; line-height: 1.5; }
+.cnp-empty-mark { display: grid; place-items: center; width: 46px; height: 46px; margin-bottom: 5px; border: 1px solid color-mix(in srgb, var(--cn-accent, #17af3d) 30%, var(--inbox-line)); border-radius: 14px; background: color-mix(in srgb, var(--cn-accent, #17af3d) 9%, var(--inbox-surface)); color: var(--cn-accent, #17af3d); font-size: 1.2rem; }
+.cnp-inbox-error button, .cnp-load-more { border: 1px solid var(--inbox-line); border-radius: 8px; background: var(--inbox-surface); color: var(--inbox-ink); padding: 8px 12px; font: 700 .74rem inherit; cursor: pointer; }
+.cnp-inbox-loading { display: grid; gap: 9px; padding: 24px 14px; }
+.cnp-inbox-loading span { height: 92px; border-radius: 11px; background: linear-gradient(100deg, var(--inbox-soft) 20%, color-mix(in srgb, var(--inbox-soft) 55%, white) 40%, var(--inbox-soft) 60%); background-size: 200% 100%; animation: cnp-shimmer 1.2s infinite; }
+.cnp-load-more { display: block; margin: 16px auto; }
+
+@keyframes cnp-shimmer { to { background-position-x: -200%; } }
+@media (prefers-reduced-motion: reduce) { .cnp-inbox-item, .cnp-inbox-loading span { transition: none; animation: none; } }

--- a/src/CretNet.Platform.Blazor/Components/CnpNotificationCenterButton.razor
+++ b/src/CretNet.Platform.Blazor/Components/CnpNotificationCenterButton.razor
@@ -1,77 +1,86 @@
-﻿@implements IDisposable
+@using CretNet.Platform.Blazor.Notifications
+@implements IDisposable
 @inject IDialogService DialogService
-@inject IMessageService MessageService
+@inject CnpNotificationState Notifications
 
-<FluentButton BackgroundColor="var(--accent-fill-rest)" OnClick="OpenNotificationCenterAsync" Title="Notification center">
-@if (MessageService.Count("MESSAGES_NOTIFICATION_CENTER") > 0)
-{
-    <FluentCounterBadge Count="@MessageService.Count("MESSAGES_NOTIFICATION_CENTER")"
-                        Max="9"
-                        ShowOverflow="true"
-                        BackgroundColor="@Color.Error"
-                        Color="Color.Fill"
-                        Appearance="Appearance.Accent">
-        <ChildContent>
-            @NotificationIcon()
-        </ChildContent>
-    </FluentCounterBadge>
-}
-else
-{
-    @NotificationIcon() 
-}
-</FluentButton>
+<button type="button"
+        class="cnp-notification-trigger cn-icon-btn"
+        title="Meldingen"
+        aria-label="Meldingen: @Notifications.UnreadCount ongelezen"
+        @onclick="OpenNotificationCenterAsync">
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M8 2.2a4 4 0 0 1 4 4v2.6l1.2 2.2H2.8L4 8.8V6.2a4 4 0 0 1 4-4Z" />
+        <path d="M6.6 13.2a1.5 1.5 0 0 0 2.8 0" />
+    </svg>
+    @if (Notifications.UnreadCount > 0)
+    {
+        <span class="cnp-notification-count">@(Notifications.UnreadCount > 99 ? "99+" : Notifications.UnreadCount)</span>
+    }
+</button>
 
 @code {
-    private IDialogReference? _dialog;
-   
+    private PeriodicTimer? _timer;
+    private CancellationTokenSource? _pollCancellation;
+
     protected override void OnInitialized()
     {
-        MessageService.OnMessageItemsUpdated += UpdateCount;    
+        Notifications.Changed += OnChanged;
+        _pollCancellation = new CancellationTokenSource();
+        _timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
+        _ = PollAsync(_pollCancellation.Token);
     }
 
-    private void UpdateCount()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        InvokeAsync(StateHasChanged);
+        if (firstRender)
+            await SafeRefreshSummaryAsync();
     }
-
-    private RenderFragment NotificationIcon() =>
-        @<FluentIcon Value="@(new Icons.Regular.Size20.Alert())" Color="Color.Fill"  Title="Notification center" />;
 
     private async Task OpenNotificationCenterAsync()
     {
-        // DemoLogger.WriteLine($"Open notification center");
-
-        _dialog = await DialogService.ShowPanelAsync<CnpNotificationCenter>(new DialogParameters<GlobalState>()
-            {
-                Alignment = HorizontalAlignment.Right,
-                Title = "Notifications",
-                PrimaryAction = null,
-                SecondaryAction = null,
-                ShowDismiss = true
-            });
-        var result = await _dialog.Result;
-        HandlePanel(result);
+        await DialogService.ShowPanelAsync<CnpNotificationCenter>(new DialogParameters<GlobalState>
+        {
+            Alignment = HorizontalAlignment.Right,
+            Title = null,
+            PrimaryAction = null,
+            SecondaryAction = null,
+            ShowDismiss = false,
+            Width = "min(440px, 100vw)"
+        });
     }
 
-    private static void HandlePanel(DialogResult result)
+    private async Task PollAsync(CancellationToken cancellationToken)
     {
-        if (result.Cancelled)
+        try
         {
-            // DemoLogger.WriteLine($"Notification center dismissed");
-            return;
+            while (_timer is not null && await _timer.WaitForNextTickAsync(cancellationToken))
+                await SafeRefreshSummaryAsync(cancellationToken);
         }
-
-        if (result.Data is not null)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // DemoLogger.WriteLine($"Notification center closed");
-            return;
         }
     }
+
+    private async Task SafeRefreshSummaryAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await Notifications.RefreshSummaryAsync(cancellationToken);
+        }
+        catch
+        {
+            // The durable inbox catches up on the next tick/open; the shell
+            // should not surface a recurring connectivity toast.
+        }
+    }
+
+    private void OnChanged() => _ = InvokeAsync(StateHasChanged);
 
     public void Dispose()
     {
-        MessageService.OnMessageItemsUpdated -= UpdateCount;
+        Notifications.Changed -= OnChanged;
+        _pollCancellation?.Cancel();
+        _pollCancellation?.Dispose();
+        _timer?.Dispose();
     }
-
 }

--- a/src/CretNet.Platform.Blazor/Components/CnpNotificationCenterButton.razor.css
+++ b/src/CretNet.Platform.Blazor/Components/CnpNotificationCenterButton.razor.css
@@ -1,0 +1,43 @@
+.cnp-notification-trigger {
+    position: relative;
+    display: inline-grid;
+    place-items: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 9px;
+    background: transparent;
+    color: var(--cn-text, #202428);
+    cursor: pointer;
+}
+
+.cnp-notification-trigger:hover {
+    border-color: var(--cn-border, #e2e5e8);
+    background: var(--cn-surface-muted, #f4f6f5);
+}
+
+.cnp-notification-trigger svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.4;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.cnp-notification-count {
+    position: absolute;
+    top: 1px;
+    right: 0;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border: 2px solid var(--cn-surface, #fff);
+    border-radius: 999px;
+    background: #cf3434;
+    color: #fff;
+    font: 700 9px/12px var(--cn-font, sans-serif);
+    text-align: center;
+}

--- a/src/CretNet.Platform.Blazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CretNet.Platform.Blazor/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using CretNet.Platform.Blazor.Services;
 using CretNet.Platform.Blazor.Services.Countries;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components;
+using CretNet.Platform.Blazor.Notifications;
 
 namespace CretNet.Platform.Blazor.Extensions;
 
@@ -25,6 +26,7 @@ public static class ServiceCollectionExtensions
         
         // Implementations
         services.AddScoped<ICnpToastService, CnpToastService>();
+        services.AddScoped<CnpNotificationState>();
         services.AddScoped<IBreadcrumbService, BreadcrumbService>();
         services.AddScoped<ICnpSectionService, CnpSectionService>();
         services.AddScoped<INavigationService, NavigationService>();

--- a/src/CretNet.Platform.Blazor/Notifications/CnpNotificationModels.cs
+++ b/src/CretNet.Platform.Blazor/Notifications/CnpNotificationModels.cs
@@ -1,0 +1,41 @@
+namespace CretNet.Platform.Blazor.Notifications;
+
+public sealed record CnpNotificationItem(
+    Guid Id,
+    string Category,
+    CnpNotificationSeverity Severity,
+    string Type,
+    string Title,
+    string Message,
+    string? ActionPath,
+    string? SubjectType,
+    Guid? SubjectId,
+    bool RequiresAction,
+    DateTimeOffset OccurredAt,
+    DateTimeOffset? ReadAt,
+    DateTimeOffset? ArchivedAt);
+
+public sealed record CnpNotificationPage(
+    IReadOnlyList<CnpNotificationItem> Items,
+    string? NextCursor);
+
+public sealed record CnpNotificationSummary(
+    int UnreadCount,
+    int ActionRequiredCount,
+    DateTimeOffset ServerTime);
+
+public enum CnpNotificationSeverity
+{
+    Information,
+    Success,
+    Warning,
+    Error
+}
+
+public enum CnpNotificationFilter
+{
+    All,
+    Unread,
+    ActionRequired,
+    Archived
+}

--- a/src/CretNet.Platform.Blazor/Notifications/CnpNotificationState.cs
+++ b/src/CretNet.Platform.Blazor/Notifications/CnpNotificationState.cs
@@ -1,0 +1,170 @@
+namespace CretNet.Platform.Blazor.Notifications;
+
+/// <summary>Scoped event-driven state for the notification bell and inbox.</summary>
+public sealed class CnpNotificationState : IDisposable
+{
+    private const int PageSize = 30;
+    private readonly ICnpNotificationClient _client;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly CancellationTokenSource _disposeCancellation = new();
+
+    public CnpNotificationState(ICnpNotificationClient client)
+    {
+        _client = client;
+    }
+
+    public event Action? Changed;
+
+    public IReadOnlyList<CnpNotificationItem> Items { get; private set; } = [];
+    public int UnreadCount { get; private set; }
+    public int ActionRequiredCount { get; private set; }
+    public CnpNotificationFilter Filter { get; private set; }
+    public string? NextCursor { get; private set; }
+    public bool IsLoading { get; private set; }
+    public bool IsLoadingMore { get; private set; }
+    public string? Error { get; private set; }
+
+    public async Task RefreshSummaryAsync(CancellationToken cancellationToken = default)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            _disposeCancellation.Token);
+        var summary = await _client.GetSummaryAsync(linked.Token);
+        UnreadCount = summary.UnreadCount;
+        ActionRequiredCount = summary.ActionRequiredCount;
+        Changed?.Invoke();
+    }
+
+    public async Task RefreshAsync(
+        CnpNotificationFilter? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            IsLoading = true;
+            Error = null;
+            if (filter.HasValue)
+                Filter = filter.Value;
+            Changed?.Invoke();
+
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                _disposeCancellation.Token);
+            var page = await _client.GetPageAsync(Filter, null, PageSize, linked.Token);
+            var summary = await _client.GetSummaryAsync(linked.Token);
+            Items = page.Items;
+            NextCursor = page.NextCursor;
+            UnreadCount = summary.UnreadCount;
+            ActionRequiredCount = summary.ActionRequiredCount;
+        }
+        catch (OperationCanceledException) when (_disposeCancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            Error = exception.Message;
+        }
+        finally
+        {
+            IsLoading = false;
+            Changed?.Invoke();
+            _gate.Release();
+        }
+    }
+
+    public async Task LoadMoreAsync(CancellationToken cancellationToken = default)
+    {
+        if (NextCursor is null || IsLoadingMore)
+            return;
+
+        IsLoadingMore = true;
+        Changed?.Invoke();
+        try
+        {
+            Error = null;
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                _disposeCancellation.Token);
+            var page = await _client.GetPageAsync(Filter, NextCursor, PageSize, linked.Token);
+            Items = Items.Concat(page.Items).DistinctBy(item => item.Id).ToList();
+            NextCursor = page.NextCursor;
+        }
+        catch (OperationCanceledException) when (_disposeCancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            Error = exception.Message;
+        }
+        finally
+        {
+            IsLoadingMore = false;
+            Changed?.Invoke();
+        }
+    }
+
+    public async Task SetReadAsync(CnpNotificationItem item, bool read, CancellationToken cancellationToken = default)
+    {
+        await ExecuteMutationAsync(async token =>
+        {
+            await _client.SetReadAsync(item.Id, read, token);
+            DateTimeOffset? timestamp = read ? DateTimeOffset.UtcNow : null;
+            Items = Items.Select(candidate => candidate.Id == item.Id
+                ? candidate with { ReadAt = timestamp }
+                : candidate).ToList();
+        }, cancellationToken);
+    }
+
+    public async Task ArchiveAsync(CnpNotificationItem item, CancellationToken cancellationToken = default)
+    {
+        await ExecuteMutationAsync(async token =>
+        {
+            await _client.ArchiveAsync(item.Id, token);
+            Items = Items.Where(candidate => candidate.Id != item.Id).ToList();
+        }, cancellationToken);
+    }
+
+    public async Task MarkAllReadAsync(CancellationToken cancellationToken = default)
+    {
+        await ExecuteMutationAsync(async token =>
+        {
+            await _client.MarkAllReadAsync(token);
+            var now = DateTimeOffset.UtcNow;
+            Items = Items.Select(item => item with { ReadAt = item.ReadAt ?? now }).ToList();
+        }, cancellationToken);
+    }
+
+    private async Task ExecuteMutationAsync(
+        Func<CancellationToken, Task> mutation,
+        CancellationToken cancellationToken)
+    {
+        Error = null;
+        try
+        {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                _disposeCancellation.Token);
+            await mutation(linked.Token);
+            await RefreshSummaryAsync(linked.Token);
+        }
+        catch (OperationCanceledException) when (_disposeCancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            Error = exception.Message;
+        }
+        finally
+        {
+            Changed?.Invoke();
+        }
+    }
+
+    public void Dispose()
+    {
+        _disposeCancellation.Cancel();
+        _disposeCancellation.Dispose();
+        _gate.Dispose();
+    }
+}

--- a/src/CretNet.Platform.Blazor/Notifications/ICnpNotificationClient.cs
+++ b/src/CretNet.Platform.Blazor/Notifications/ICnpNotificationClient.cs
@@ -1,0 +1,19 @@
+namespace CretNet.Platform.Blazor.Notifications;
+
+/// <summary>
+/// Host-provided transport for the reusable notification inbox. CretNet owns
+/// presentation and state, while the host owns persistence and authorization.
+/// </summary>
+public interface ICnpNotificationClient
+{
+    Task<CnpNotificationPage> GetPageAsync(
+        CnpNotificationFilter filter,
+        string? cursor,
+        int take,
+        CancellationToken cancellationToken);
+
+    Task<CnpNotificationSummary> GetSummaryAsync(CancellationToken cancellationToken);
+    Task SetReadAsync(Guid id, bool read, CancellationToken cancellationToken);
+    Task ArchiveAsync(Guid id, CancellationToken cancellationToken);
+    Task MarkAllReadAsync(CancellationToken cancellationToken);
+}

--- a/src/CretNet.Platform.Blazor/Services/CnpToastService.cs
+++ b/src/CretNet.Platform.Blazor/Services/CnpToastService.cs
@@ -6,37 +6,30 @@ using IFluentToastService = IToastService;
 
 public class CnpToastService : ICnpToastService
 {
-    private readonly IMessageService _messageService;
     private readonly IFluentToastService _fluentToastService;
 
-    public CnpToastService(IMessageService messageService, IFluentToastService fluentToastService)
+    public CnpToastService(IFluentToastService fluentToastService)
     {
-        _messageService = messageService;
         _fluentToastService = fluentToastService;
     }
     
     public void Show(ToastTypes toastType, string title, string message, params object[] messageParameters)
     {
         var toastIntent = ToastIntent.Custom;
-        var messageIntent = MessageIntent.Custom;
 
         switch (toastType)
         {
             case ToastTypes.Info:
                 toastIntent = ToastIntent.Info;
-                messageIntent = MessageIntent.Info;
                 break;
             case ToastTypes.Success:
                 toastIntent = ToastIntent.Success;
-                messageIntent = MessageIntent.Success;
                 break;
             case ToastTypes.Warning:
                 toastIntent = ToastIntent.Warning;
-                messageIntent = MessageIntent.Warning;
                 break;
             case ToastTypes.Error:
                 toastIntent = ToastIntent.Error;
-                messageIntent = MessageIntent.Error;
                 break;
             default:
                 break;
@@ -50,15 +43,6 @@ public class CnpToastService : ICnpToastService
         if (messageParameters.Length != 0)
             formattedMessage = Smart.Format(message, messageParameters);
         
-        _messageService.ShowMessageBar(options =>
-        {
-            options.Intent = messageIntent;
-            options.Title = formattedTitle;
-            options.Body = formattedMessage.Replace("\r\n", "<br/>");
-            options.Timestamp = DateTime.Now;
-            options.Section = "MESSAGES_NOTIFICATION_CENTER";
-        });
-
         _fluentToastService.ShowCommunicationToast(new ToastParameters<CommunicationToastContent>()
         {
             Intent = toastIntent,


### PR DESCRIPTION
## What changed

- replace the transient toast-backed message panel with a durable notification inbox
- add transport-neutral notification contracts and client state
- add accessible unread, action-required and archived filtering
- keep synchronous toast feedback separate from durable background outcomes

## Why

HCMT needs a reusable CretNet notification surface whose state is owned by the
server and remains consistent across reloads and devices.

## Validation

- `dotnet test src/CretNet.Tests/CretNet.Tests.csproj` — 20 passed
- HCMT solution build using the local CretNet source — 0 warnings, 0 errors
- HCMT notification state, component and integration suites — passed
